### PR TITLE
Fix hooking on modern bag API

### DIFF
--- a/IDontWantThat/idontwantthat.lua
+++ b/IDontWantThat/idontwantthat.lua
@@ -542,7 +542,11 @@ local function handleItemClick(self, button)
     markWares()
 end
 
-hooksecurefunc("ContainerFrameItemButton_OnModifiedClick", handleItemClick)
+if type(ContainerFrameItemButton_OnModifiedClick) == "function" then
+    hooksecurefunc("ContainerFrameItemButton_OnModifiedClick", handleItemClick)
+elseif ContainerFrameItemButtonMixin and ContainerFrameItemButtonMixin.OnModifiedClick then
+    hooksecurefunc(ContainerFrameItemButtonMixin, "OnModifiedClick", handleItemClick)
+end
 
 -- Add slash commands for options
 local function addSlashCommand(name, func, ...)


### PR DESCRIPTION
## Summary
- protect ContainerFrameItemButton_OnModifiedClick hook
- fall back to ContainerFrameItemButtonMixin if the global function is unavailable

## Testing
- `lua` not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_68896d769654832e8e05e5beca261c70