### PR TITLE
Fix crash when `IsAddOnLoaded` is missing

### DIFF
--- a/IDontWantThat/idontwantthat.lua
+++ b/IDontWantThat/idontwantthat.lua
@@ -8,6 +8,9 @@ local LAST_BAG = (NUM_TOTAL_EQUIPPED_BAG_SLOTS or 5) - 1
 local getContainerNumSlots = GetContainerNumSlots
 local getContainerItemLink = GetContainerItemLink
 local pickupContainerItem = PickupContainerItem
+local IsAddOnLoaded = _G.IsAddOnLoaded or function()
+    return false
+end
 if C_Container then
     getContainerNumSlots = C_Container.GetContainerNumSlots
     getContainerItemLink = C_Container.GetContainerItemLink


### PR DESCRIPTION
## Summary
- provide a fallback implementation for `IsAddOnLoaded`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68896e0bf268832e9ebf7d64f027d37b