### PR TITLE
Fix coin overlay size

### DIFF
--- a/IDontWantThat/idontwantthat.lua
+++ b/IDontWantThat/idontwantthat.lua
@@ -53,6 +53,7 @@ local function showCoinTexture(itemButton)
     if not itemButton.coins_delete then
         local texture = itemButton:CreateTexture(nil, "OVERLAY")
         texture:SetTexture("Interface\\AddOns\\IDontWantThat\\coins_delete")
+        texture:SetSize(16, 16)
 
         -- Default padding for making bottom-right look great.
         local paddingX, paddingY = -3, 1


### PR DESCRIPTION
## Summary
- fix missing coin overlay by giving the texture a size

## Testing
- `git show -s --stat`

------
https://chatgpt.com/codex/tasks/task_e_688971d54e58832ebf6f158afb5f36c1